### PR TITLE
ci: nix flake check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v12
       - uses: DeterminateSystems/magic-nix-cache-action@v7
-      - run: nix flake check
+      - name: Check Nix flake Nixpkgs inputs
+        uses: DeterminateSystems/flake-checker-action@main
+      - run: nix flake check --no-build
       - name: Install direnv with Nix
         uses: aldoborrero/direnv-nix-action@v2
         with:


### PR DESCRIPTION
- adds `DeterminateSystems/flake-checker-action@main`
- uses `--no-build` for the built-in check, due to speed issues with this step