### PR TITLE
fix: field_values types for dropdowns

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
         run: yamlfmt -lint .
       - name: Format
         run: deno task format
+      - name: Check types
+        run: deno task check
       - name: Test
         run: deno task test:coverage
       - name: Archive code coverage results

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -11,6 +11,7 @@
     },
     "tasks": {
         "build": "deno run -A scripts/build_npm.ts",
+        "check": "deno check src/**/*.ts",
         "test": "deno test --allow-env=API_KEY,NODE_EXTRA_CA_CERTS --allow-net=api.affinity.co --doc --allow-read=./src/v1/tests/ src/**/tests/",
         "test:coverage": "deno task test --coverage=cov_profile && deno coverage cov_profile --html",
         "watch": "deno task test --no-clear-screen --watch --shuffle --parallel",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -29,6 +29,7 @@
         ],
         "exclude": [
             "src/**/fixtures/**/*.ts",
+            "dist/",
             "docs/"
         ],
         "rules": {
@@ -52,8 +53,9 @@
         "proseWrap": "always",
         "exclude": [
             "cov_profile/",
-            "npm/",
             "docs/",
+            "dist/",
+            "npm/",
             "openapi/",
             "src/**/tests/__snapshots__/**"
         ]

--- a/src/v1/field_value_changes.ts
+++ b/src/v1/field_value_changes.ts
@@ -5,6 +5,7 @@ import type { DateTime } from './types.ts'
 import { fieldValueChangesUrl } from './urls.ts'
 import { defaultTransformers } from './axios_default_transformers.ts'
 import type { Field } from './lists.ts'
+import type { Value, ValueRaw } from './field_values.ts'
 
 /**
  * Via https://stackoverflow.com/questions/40510611
@@ -35,33 +36,14 @@ export enum ActionType {
     UPDATE = 2,
 }
 
-export type Changer = {
-    /**
-     * The unique identifier of the changer.
-     */
-    id: number
-} & Person
-
-export type Value = {
-    /**
-     * The unique identifier of the value.
-     */
-    id: number
-    /**
-     * Represents the field's value.
-     */
-    text: string
-    /**
-     * The rank of the value.
-     *
-     * TODO(@joscha): can this be null for some value types?
-     */
-    rank: number
-    /**
-     * The color associated with the value.
-     */
-    color: number
-}
+export type Changer =
+    & Person
+    & {
+        /**
+         * The unique identifier of the changer.
+         */
+        id: number
+    }
 
 /**
  * Represents the response object for a field value change.
@@ -103,14 +85,16 @@ export type FieldValueChangeRaw = {
      * This attribute can take on many different types, depending on the field `value_type`.
      * When the action type is {@link ActionType.DELETE}, `value` represents the old value; otherwise, it represents the new value.
      */
-    value: Value
+    value: ValueRaw
 }
 
 export type FieldValueChangeResponseRaw = FieldValueChangeRaw[]
 
-export type FieldValueChange = Omit<FieldValueChangeRaw, 'changed_at'> & {
-    changed_at: Date
-}
+export type FieldValueChange =
+    & Omit<FieldValueChangeRaw, 'changed_at'>
+    & {
+        changed_at: Date
+    }
 
 export type FieldValueChangeResponse = FieldValueChange[]
 
@@ -188,6 +172,9 @@ export class FieldValueChanges {
     constructor(private readonly axios: AxiosInstance) {
     }
 
+    /**
+     * TODO(@joscha): transform DateTime values to Date objects and then change type {@link ValueRaw} to {@link Value}
+     */
     private static transformFieldValueChange(
         fieldValueChange: FieldValueChangeRaw,
     ): FieldValueChange {

--- a/src/v1/field_values.ts
+++ b/src/v1/field_values.ts
@@ -65,6 +65,51 @@ export interface FieldValueRawValues
     [FieldValueType.TEXT]: TextValue
 }
 
+export interface FieldValueValues extends Record<keyof FieldValueType, Value> {
+    [FieldValueType.RANKED_DROPDOWN]: RankedDropdownValue
+    [FieldValueType.DROPDOWN]: DropdownValue
+    [FieldValueType.NUMBER]: NumberValue
+    [FieldValueType.PERSON]: PersonValue
+    [FieldValueType.ORGANIZATION]: OrganizationValue
+    [FieldValueType.LOCATION]: LocationValue
+    [FieldValueType.DATE]: Date
+    [FieldValueType.TEXT]: TextValue
+}
+
+type ValueTypeMixin<T extends (FieldValueRawValues | FieldValueValues)> =
+    | {
+        value_type: FieldValueType.DROPDOWN
+        value: T[FieldValueType.DROPDOWN]
+    }
+    | {
+        value_type: FieldValueType.RANKED_DROPDOWN
+        value: T[FieldValueType.RANKED_DROPDOWN]
+    }
+    | {
+        value_type: FieldValueType.NUMBER
+        value: T[FieldValueType.NUMBER]
+    }
+    | {
+        value_type: FieldValueType.PERSON
+        value: T[FieldValueType.PERSON]
+    }
+    | {
+        value_type: FieldValueType.ORGANIZATION
+        value: T[FieldValueType.ORGANIZATION]
+    }
+    | {
+        value_type: FieldValueType.LOCATION
+        value: T[FieldValueType.LOCATION]
+    }
+    | {
+        value_type: FieldValueType.DATE
+        value: T[FieldValueType.DATE]
+    }
+    | {
+        value_type: FieldValueType.TEXT
+        value: T[FieldValueType.TEXT]
+    }
+
 /**
  * Each field value object has a unique id.
  *
@@ -98,10 +143,6 @@ export type FieldValueRaw =
          */
         list_entry_id: number | null
         /**
-         * The value attribute can take on many different types, depending on the field {@link Field.value_type}.
-         */
-        value: ValueRaw
-        /**
          * The string representing the time when the field value was created.
          */
         created_at: DateTime
@@ -110,54 +151,17 @@ export type FieldValueRaw =
          */
         updated_at: DateTime | null
     }
-    & (
-        | {
-            value_type: FieldValueType.DROPDOWN
-            value: FieldValueRawValues[FieldValueType.DROPDOWN]
-        }
-        | {
-            value_type: FieldValueType.RANKED_DROPDOWN
-            value: RankedDropdownValue
-        }
-        | {
-            value_type: FieldValueType.NUMBER
-            value: FieldValueRawValues[FieldValueType.NUMBER]
-        }
-        | {
-            value_type: FieldValueType.PERSON
-            value: FieldValueRawValues[FieldValueType.PERSON]
-        }
-        | {
-            value_type: FieldValueType.ORGANIZATION
-            value: FieldValueRawValues[FieldValueType.ORGANIZATION]
-        }
-        | {
-            value_type: FieldValueType.LOCATION
-            value: FieldValueRawValues[FieldValueType.LOCATION]
-        }
-        | {
-            value_type: FieldValueType.DATE
-            value: FieldValueRawValues[FieldValueType.DATE]
-        }
-        | {
-            value_type: FieldValueType.TEXT
-            value: FieldValueRawValues[FieldValueType.TEXT]
-        }
-    )
+    & ValueTypeMixin<FieldValueRawValues>
 
 export type FieldValueResponseRaw = FieldValueRaw[]
 
 export type FieldValue =
     & Omit<FieldValueRaw, 'value' | 'updated_at' | 'created_at'>
     & {
-        value: Value
         updated_at: Date | null
         created_at: Date
     }
-    & {
-        value_type: FieldValueType.DATE
-        value: Date
-    }
+    & ValueTypeMixin<FieldValueValues>
 
 export type FieldValueResponse = FieldValue[]
 
@@ -211,50 +215,19 @@ export class FieldValues {
     constructor(private readonly axios: AxiosInstance) {
     }
 
-    private static isValidISO8601(dateString: string): boolean {
-        // Define the regular expression for ISO 8601 format
-        const iso8601Regex =
-            /^(-?(?:[1-9][0-9]*)?[0-9]{4})(-(0[1-9]|1[0-2])(-([0-2][0-9]|3[01])(T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(\.\d+)?(Z|([+-]([01][0-9]|2[0-3]):[0-5][0-9])))?)?)?$/
-
-        // Check if the string matches the ISO 8601 format
-        if (!iso8601Regex.test(dateString)) {
-            return false
-        }
-
-        // Parse the date using the Date object
-        const date = new Date(dateString)
-        return date.toISOString() === dateString
-    }
-
-    private static transformValue(value: ValueRaw): Value
-    private static transformValue(value: Value): ValueRaw
-    private static transformValue(value: Value | ValueRaw): Value | ValueRaw {
-        if (value instanceof Date) {
-            return value.toISOString() as DateTime
-        } else if (
-            typeof value === 'string' && FieldValues.isValidISO8601(value)
-        ) {
-            // TODO(@joscha): introspection of the value shape is not ideal, as it will transform a text value that happens
-            // to be a valid ISO date string into a Date object. This is a limitation of the current design.
-            // A way around this can be to fetch the field definition and use that to determine the value type.
-            // The attached cost is an additional API request for each field value in string shape, which is not ideal.
-            return new Date(value)
-        } else {
-            return value
-        }
-    }
-
     private static transformFieldValue(
         fieldValue: FieldValueRaw,
     ): FieldValue {
         return {
             ...fieldValue,
-            value: FieldValues.transformValue(fieldValue.value),
+            value: fieldValue.value_type === FieldValueType.DATE
+                ? new Date(fieldValue.value)
+                : fieldValue.value,
             updated_at: fieldValue.updated_at === null
                 ? null
                 : new Date(fieldValue.updated_at),
             created_at: new Date(fieldValue.created_at),
-        }
+        } as FieldValue
     }
 
     /**
@@ -305,7 +278,9 @@ export class FieldValues {
             fieldValuesUrl(),
             {
                 ...data,
-                value: FieldValues.transformValue(data.value),
+                value: data.value instanceof Date
+                    ? data.value.toISOString()
+                    : data.value,
             },
             {
                 transformResponse: [
@@ -337,7 +312,11 @@ export class FieldValues {
     async update(data: UpdateFieldValueRequest): Promise<FieldValue> {
         const response = await this.axios.put<FieldValue>(
             fieldValuesUrl(data.field_value_id),
-            { value: FieldValues.transformValue(data.value) },
+            {
+                value: data.value instanceof Date
+                    ? data.value.toISOString()
+                    : data.value,
+            },
             {
                 transformResponse: [
                     ...defaultTransformers(),

--- a/src/v1/field_values.ts
+++ b/src/v1/field_values.ts
@@ -4,9 +4,32 @@ import { defaultTransformers } from './axios_default_transformers.ts'
 import { FieldValueType } from './lists.ts'
 import { Field } from './lists.ts'
 import type { DateTime } from './types.ts'
+import { FieldBase } from './fields.ts'
 export type { DateTime } from './types.ts'
 
-export type DropdownValue = string
+export type DropdownValue = {
+    /**
+     * The unique identifier of the value.
+     */
+    id: number
+    /**
+     * Represents the field's value.
+     */
+    text: string
+    /**
+     * The color associated with the value.
+     */
+    color: number
+}
+
+export type RankedDropdownValue =
+    & DropdownValue
+    & {
+        /**
+         * The rank of the value.
+         */
+        rank: number
+    }
 export type NumberValue = number
 export type PersonValue = number
 export type OrganizationValue = number
@@ -21,6 +44,7 @@ export type TextValue = string
 
 export type ValueRaw =
     | DropdownValue
+    | RankedDropdownValue
     | NumberValue
     | PersonValue
     | OrganizationValue
@@ -31,7 +55,7 @@ export type Value = Omit<ValueRaw, DateTime> | Date
 
 export interface FieldValueRawValues
     extends Record<keyof FieldValueType, ValueRaw> {
-    [FieldValueType.RANKED_DROPDOWN]: DropdownValue
+    [FieldValueType.RANKED_DROPDOWN]: RankedDropdownValue
     [FieldValueType.DROPDOWN]: DropdownValue
     [FieldValueType.NUMBER]: NumberValue
     [FieldValueType.PERSON]: PersonValue
@@ -53,36 +77,39 @@ export interface FieldValueRawValues
  *
  * *Note*: When retrieving Field Values from a specific cell in your Affinity list, it may be helpful to think about it as an XY coordinate system. The X coordinate is the List Entry *or* Entity and the Y coordinate is the Field ID. You will need to have both to find the appropriate Field Value ID.
  */
-export type FieldValueRaw = {
-    /**
-     * The unique identifier of the field value object.
-     */
-    id: number
-    /**
-     * The unique identifier of the field the value is associated with.
-     */
-    field_id: number
-    /**
-     * The unique identifier of the person, organization, or opportunity object the field value is associated with.
-     */
-    entity_id: number
-    /**
-     * The unique identifier of the list entry object the field value is associated with. This only exists if the field the value is associated with is list-specific.
-     */
-    list_entry_id: number | null
-    /**
-     * The value attribute can take on many different types, depending on the field {@link Field.value_type}.
-     */
-    value: ValueRaw
-    /**
-     * The string representing the time when the field value was created.
-     */
-    created_at: DateTime
-    /**
-     * The string representing the last time the field value was updated.
-     */
-    updated_at: DateTime | null
-}
+export type FieldValueRaw =
+    & FieldBase
+    & {
+        /**
+         * The unique identifier of the field value object.
+         */
+        id: number
+        /**
+         * The unique identifier of the field the value is associated with.
+         */
+        field_id: number
+        /**
+         * The unique identifier of the person, organization, or opportunity object the field value is associated with.
+         */
+        entity_id: number
+        /**
+         * The unique identifier of the list entry object the field value is associated with.
+         * This only exists if the field the value is associated with is list-specific, `null` marks a global field value.
+         */
+        list_entry_id: number | null
+        /**
+         * The value attribute can take on many different types, depending on the field {@link Field.value_type}.
+         */
+        value: ValueRaw
+        /**
+         * The string representing the time when the field value was created.
+         */
+        created_at: DateTime
+        /**
+         * The string representing the last time the field value was updated.
+         */
+        updated_at: DateTime | null
+    }
 
 export type FieldValueResponseRaw = FieldValueRaw[]
 
@@ -108,19 +135,23 @@ export type UpdateFieldValueRequest = {
     value: Value
 }
 
-export type AllQueryParameters = {
-    /** The unique ID of the person object whose field values are to be retrieved. */
-    person_id: number
-} | {
-    /** The unique ID of the organization object whose field values are to be retrieved. */
-    organization_id: number
-} | {
-    /** The unique ID of the opportunity object whose field values are to be retrieved. */
-    opportunity_id: number
-} | {
-    /** The unique ID of the list entry object whose field values are to be retrieved. */
-    list_entry_id: number
-}
+export type AllQueryParameters =
+    | {
+        /** The unique ID of the person object whose field values are to be retrieved. */
+        person_id: number
+    }
+    | {
+        /** The unique ID of the organization object whose field values are to be retrieved. */
+        organization_id: number
+    }
+    | {
+        /** The unique ID of the opportunity object whose field values are to be retrieved. */
+        opportunity_id: number
+    }
+    | {
+        /** The unique ID of the list entry object whose field values are to be retrieved. */
+        list_entry_id: number
+    }
 
 /**
  * @module

--- a/src/v1/field_values.ts
+++ b/src/v1/field_values.ts
@@ -110,6 +110,40 @@ export type FieldValueRaw =
          */
         updated_at: DateTime | null
     }
+    & (
+        | {
+            value_type: FieldValueType.DROPDOWN
+            value: FieldValueRawValues[FieldValueType.DROPDOWN]
+        }
+        | {
+            value_type: FieldValueType.RANKED_DROPDOWN
+            value: RankedDropdownValue
+        }
+        | {
+            value_type: FieldValueType.NUMBER
+            value: FieldValueRawValues[FieldValueType.NUMBER]
+        }
+        | {
+            value_type: FieldValueType.PERSON
+            value: FieldValueRawValues[FieldValueType.PERSON]
+        }
+        | {
+            value_type: FieldValueType.ORGANIZATION
+            value: FieldValueRawValues[FieldValueType.ORGANIZATION]
+        }
+        | {
+            value_type: FieldValueType.LOCATION
+            value: FieldValueRawValues[FieldValueType.LOCATION]
+        }
+        | {
+            value_type: FieldValueType.DATE
+            value: FieldValueRawValues[FieldValueType.DATE]
+        }
+        | {
+            value_type: FieldValueType.TEXT
+            value: FieldValueRawValues[FieldValueType.TEXT]
+        }
+    )
 
 export type FieldValueResponseRaw = FieldValueRaw[]
 
@@ -119,6 +153,10 @@ export type FieldValue =
         value: Value
         updated_at: Date | null
         created_at: Date
+    }
+    & {
+        value_type: FieldValueType.DATE
+        value: Date
     }
 
 export type FieldValueResponse = FieldValue[]

--- a/src/v1/fields.ts
+++ b/src/v1/fields.ts
@@ -5,40 +5,47 @@ import { EntityType, Field, FieldValueType } from './lists.ts'
 
 export type FieldResponse = Field[]
 
-export type FieldsQueryParameters = {
-    /**
-     * An unique identifier of the list whose fields are to be retrieved.
-     *
-     * Pass the `list_id` to only fetch fields that are specific to that list. Otherwise, all global and list-specific fields will be returned.
-     */
-    list_id?: number
+export type FieldBase = {
     /**
      * The value type of the fields that are to be retrieved.
      *
      * Pass the `value_type` to fetch fields of specific value types. Otherwise, all fields of any type will be returned.
      */
-    value_type?: FieldValueType
+    value_type: FieldValueType
     /**
      * The entity type of the fields that are to be retrieved.
      *
      * Pass the `entity_type` to fetch fields of specific entity types. Otherwise, any fields of any entity type will be returned.
      */
-    entity_type?: EntityType
-    /**
-     * When `true`, field names will return in the format `[List Name] Field Name`.
-     *
-     * Pass the `with_modified_names` flag to return the fields such that the names have the list name prepended to them in the format `[List Name] Field Name` (i.e. `[Deals] Status`).
-     */
-    with_modified_names?: boolean
-    /**
-     * When true, dropdown options will not be returned in the response.
-     *
-     * Pass the `exclude_dropdown_options` flag to exclude dropdown options from the response. This may be useful when the payload is too large due to too many dropdown options.
-     */
-    exclude_dropdown_options?: boolean
+    entity_type: EntityType
 }
 
+export type FieldsQueryParameters =
+    & Partial<FieldBase>
+    & {
+        /**
+         * An unique identifier of the list whose fields are to be retrieved.
+         *
+         * Pass the `list_id` to only fetch fields that are specific to that list. Otherwise, all global and list-specific fields will be returned.
+         */
+        list_id?: number
+
+        /**
+         * When `true`, field names will return in the format `[List Name] Field Name`.
+         *
+         * Pass the `with_modified_names` flag to return the fields such that the names have the list name prepended to them in the format `[List Name] Field Name` (i.e. `[Deals] Status`).
+         */
+        with_modified_names?: boolean
+        /**
+         * When true, dropdown options will not be returned in the response.
+         *
+         * Pass the `exclude_dropdown_options` flag to exclude dropdown options from the response. This may be useful when the payload is too large due to too many dropdown options.
+         */
+        exclude_dropdown_options?: boolean
+    }
+
 export type FieldCreateParameters =
+    & FieldBase
     & {
         /**
          * The name of the field.

--- a/src/v1/list_entries.ts
+++ b/src/v1/list_entries.ts
@@ -51,16 +51,18 @@ export type ListEntryReferenceRaw = {
     created_at: DateTime
 }
 
-export type ListEntryResponseRaw = ListEntryReferenceRaw & {
-    /**
-     * The type of the entity corresponding to the list entry.
-     */
-    entity_type: EntityType
-    /**
-     * Object containing entity-specific details like name, email address, domain etc. for the entity corresponding to entity_id.
-     */
-    entity: Entity
-}
+export type ListEntryResponseRaw =
+    & ListEntryReferenceRaw
+    & {
+        /**
+         * The type of the entity corresponding to the list entry.
+         */
+        entity_type: EntityType
+        /**
+         * Object containing entity-specific details like name, email address, domain etc. for the entity corresponding to entity_id.
+         */
+        entity: Entity
+    }
 
 export type PagedListEntryResponseRaw = {
     list_entries: ListEntryResponseRaw[]

--- a/src/v1/organizations.ts
+++ b/src/v1/organizations.ts
@@ -60,36 +60,38 @@ export type Organization = {
  * Dates of the most recent and upcoming interactions with an organization are available in the interaction_dates field.
  * This data is only included when passing `with_interaction_dates=true` as a query parameter to the `GET /organizations` or the `GET /organizations/{organization_id}` endpoints.
  */
-export type OrganizationResponseRaw = Organization & {
-    /**
-     * An array of unique identifiers of people ({@link Person.id}) that are associated with the organization.
-     */
-    person_ids?: number[]
-    /**
-     * An array of unique identifiers of opportunities ({@link Opportunity.id}) that are associated with the organization.
-     */
-    opportunity_ids?: number[]
+export type OrganizationResponseRaw =
+    & Organization
+    & {
+        /**
+         * An array of unique identifiers of people ({@link Person.id}) that are associated with the organization.
+         */
+        person_ids?: number[]
+        /**
+         * An array of unique identifiers of opportunities ({@link Opportunity.id}) that are associated with the organization.
+         */
+        opportunity_ids?: number[]
 
-    /**
-     * An object with string date fields representing the most recent and upcoming interactions with this organization.
-     * Only returned when passing with_interaction_dates=true.
-     *
-     * TODO(@joscha): model this in the type system, so the return type is based on the query parameter type.
-     */
-    interaction_dates?: {
-        [key in InteractionDateKey]: DateTime
+        /**
+         * An object with string date fields representing the most recent and upcoming interactions with this organization.
+         * Only returned when passing with_interaction_dates=true.
+         *
+         * TODO(@joscha): model this in the type system, so the return type is based on the query parameter type.
+         */
+        interaction_dates?: {
+            [key in InteractionDateKey]: DateTime
+        }
+        /**
+         * An object with seven fields nested underneath.
+         * Each field corresponds to one of the seven interactions, and includes nested fields for date and person_ids which indicates the internal people associated with that event (people only returned if passing `{@link InteractionDatesQueryParams.with_interaction_persons}=true`).
+         * Only returned when passing `with_interaction_dates=true`.
+         *
+         * TODO(@joscha): model this in the type system, so the return type is based on the query parameter type.
+         */
+        interactions?: {
+            [key in InteractionType]: InteractionDateRaw
+        }
     }
-    /**
-     * An object with seven fields nested underneath.
-     * Each field corresponds to one of the seven interactions, and includes nested fields for date and person_ids which indicates the internal people associated with that event (people only returned if passing `{@link InteractionDatesQueryParams.with_interaction_persons}=true`).
-     * Only returned when passing `with_interaction_dates=true`.
-     *
-     * TODO(@joscha): model this in the type system, so the return type is based on the query parameter type.
-     */
-    interactions?: {
-        [key in InteractionType]: InteractionDateRaw
-    }
-}
 
 export type SimpleOrganizationResponse =
     & Organization
@@ -133,12 +135,14 @@ export type PagedOrganizationResponse =
         organizations: OrganizationResponse[]
     }
 
-export type SingleOrganizationResponseRaw = OrganizationResponseRaw & {
-    /**
-     * An array of list entry resources associated with the organization, only returned as part of the {@link Organizations.get} a specific organization endpoint.
-     */
-    list_entries: ListEntryReferenceRaw[]
-}
+export type SingleOrganizationResponseRaw =
+    & OrganizationResponseRaw
+    & {
+        /**
+         * An array of list entry resources associated with the organization, only returned as part of the {@link Organizations.get} a specific organization endpoint.
+         */
+        list_entries: ListEntryReferenceRaw[]
+    }
 
 export type ListEntryReference = Omit<ListEntryReferenceRaw, 'created_at'> & {
     created_at: Date
@@ -163,21 +167,23 @@ export type CreateOrganizationRequest = {
     person_ids?: number[]
 }
 
-export type UpdateOrganizationRequest = OrganizationReference & {
-    /**
-     * The name of the organization.
-     */
-    name?: string
-    /**
-     * The domain name of the organization.
-     */
-    domain?: string
-    /**
-     * An array of unique identifiers of persons that the organization will be associated with.
-     * *Note*: If you are trying to add a person to an organization, the existing values for `person_ids` must also be passed into the endpoint.
-     */
-    person_ids?: number[]
-}
+export type UpdateOrganizationRequest =
+    & OrganizationReference
+    & {
+        /**
+         * The name of the organization.
+         */
+        name?: string
+        /**
+         * The domain name of the organization.
+         */
+        domain?: string
+        /**
+         * An array of unique identifiers of persons that the organization will be associated with.
+         * *Note*: If you are trying to add a person to an organization, the existing values for `person_ids` must also be passed into the endpoint.
+         */
+        person_ids?: number[]
+    }
 
 export type InteractionTypeWithoutChat = Exclude<
     InteractionType,
@@ -192,16 +198,18 @@ export type OptionalMaxQueryParams = {
     [key in InteractionTypeWithoutChat & string as `max_${key}_date`]?: Date
 }
 
-export type InteractionDatesQueryParams = {
-    /** When true, interaction dates will be present on the returned resources. */
-    with_interaction_dates?: boolean
-} | {
-    with_interaction_dates: true
-    /**
-     * When true, persons for each interaction will be returned. Used in conjunction with `with_interaction_dates`
-     */
-    with_interaction_persons: true
-}
+export type InteractionDatesQueryParams =
+    | {
+        /** When true, interaction dates will be present on the returned resources. */
+        with_interaction_dates?: boolean
+    }
+    | {
+        with_interaction_dates: true
+        /**
+         * When true, persons for each interaction will be returned. Used in conjunction with `with_interaction_dates`
+         */
+        with_interaction_persons: true
+    }
 
 export type OpportunitiesQueryParams = {
     /**

--- a/src/v1/tests/__snapshots__/field_values_test.ts.snap
+++ b/src/v1/tests/__snapshots__/field_values_test.ts.snap
@@ -64,5 +64,6 @@ snapshot[`field_values > can update a field value with a date  1`] = `
   list_entry_id: null,
   updated_at: 2023-02-06T16:53:08.914Z,
   value: 1985-11-05T00:53:20.000Z,
+  value_type: 4,
 }
 `;

--- a/src/v1/tests/fixtures/field_values/update2.raw.response.json
+++ b/src/v1/tests/fixtures/field_values/update2.raw.response.json
@@ -3,6 +3,7 @@
     "field_id": 1234,
     "list_entry_id": null,
     "entity_id": 5678,
+    "value_type": 4,
     "created_at": "2022-10-04T10:37:19.418-04:00",
     "updated_at": "2023-02-06T11:53:08.914-05:00",
     "value": "1985-11-05T00:53:20.000Z"


### PR DESCRIPTION
Fixes the `value` field type for values that are dropdowns and ranked dropdowns.
Some style changes for union types. 
Best viewed with ignored whitespace