### PR TITLE
simplify person creation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722267763,
-        "narHash": "sha256-E22vXGsS/NK1T0oZWDbI+E34+oGJHk9YUkszDYInUIU=",
+        "lastModified": 1722335482,
+        "narHash": "sha256-ogz81JDwIyuX67JC2dZUr3tIPqJABgSKJF9tynZLksQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f4f322d1424aa547eba9cb092f905f5ceb9b639c",
+        "rev": "3563397b2f10ffa1891e1a6ce99d13d960d73acd",
         "type": "github"
       },
       "original": {

--- a/src/v1/persons.ts
+++ b/src/v1/persons.ts
@@ -350,8 +350,8 @@ export class Persons {
         const response = await this.axios.post<SimplePersonResponse>(
             personsUrl(),
             {
-                emails: [], // the API requires this field to be present
                 ...data,
+                emails: data.emails ?? [], // the API requires this field to be present
             },
         )
         return response.data

--- a/src/v1/persons.ts
+++ b/src/v1/persons.ts
@@ -145,7 +145,7 @@ export type CreatePersonRequest = {
     /**
      * The email addresses of the person. If there are no email addresses, please specify an empty array.
      */
-    emails: string[]
+    emails?: string[]
     /**
      * An array of unique identifiers of organizations that the person is associated with.
      */
@@ -349,7 +349,10 @@ export class Persons {
     ): Promise<SimplePersonResponse> {
         const response = await this.axios.post<SimplePersonResponse>(
             personsUrl(),
-            data,
+            {
+                emails: [], // the API requires this field to be present
+                ...data,
+            },
         )
         return response.data
     }


### PR DESCRIPTION
The API requires the emails field to be present, but it can be empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced flexibility in creating person requests by making the `emails` field optional.

- **Bug Fixes**
	- Ensured the `emails` field is included in the API request, even when empty, ensuring compliance with API requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->