### PR TITLE
fix: persons search

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722267763,
-        "narHash": "sha256-E22vXGsS/NK1T0oZWDbI+E34+oGJHk9YUkszDYInUIU=",
+        "lastModified": 1722335482,
+        "narHash": "sha256-ogz81JDwIyuX67JC2dZUr3tIPqJABgSKJF9tynZLksQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f4f322d1424aa547eba9cb092f905f5ceb9b639c",
+        "rev": "3563397b2f10ffa1891e1a6ce99d13d960d73acd",
         "type": "github"
       },
       "original": {

--- a/src/v1/persons.ts
+++ b/src/v1/persons.ts
@@ -47,8 +47,6 @@ export type Person = {
     emails: string[]
     /** The email (automatically computed) that is most likely to the current active email address of the person. */
     primary_email: string
-    /** An array of unique identifiers of organizations that the person is associated with. */
-    organization_ids: number[]
 }
 
 /**
@@ -106,11 +104,14 @@ export type PagedPersonResponse = Replace<PagedPersonResponseRaw, {
 
 export type SinglePersonResponseRaw =
     & {
+        /** An array of unique identifiers of organizations that the person is associated with. */
+        organization_ids: number[]
         list_entries: ListEntryReferenceRaw[]
     }
     & PersonResponseRaw
 
-export type SinglePersonResponse =
+export type SinglePersonResponse = Replace<
+    SinglePersonResponseRaw,
     & {
         /**
          * An array of list entry resources associated with the person, only returned as part of the {@link Persons.get} a specific person endpoint.
@@ -118,6 +119,7 @@ export type SinglePersonResponse =
         list_entries: ListEntryReference[]
     }
     & PersonResponse
+>
 
 export type GetPersonRequest =
     & PersonReference
@@ -183,12 +185,7 @@ export type UpdatePersonRequest =
     }
     & PersonReference
 
-export type SimplePersonResponse =
-    & Person
-    & Pick<
-        PersonResponse,
-        'organization_ids'
-    >
+export type SimplePersonResponse = Omit<SinglePersonResponse, 'list_entries'>
 
 /**
  * @module


### PR DESCRIPTION
 persons/search endpoint does not return `organization_ids`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the organization handling within the person data structure, streamlining how organizational affiliations are accessed in API responses.
	- Introduced new response types to improve clarity and usability when fetching individual person data.
  
- **Bug Fixes**
	- Corrected the representation of organizational identifiers to ensure they are still accessible and relevant in the response context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->