### PR TITLE
fix: V2 query parameters need to be exploded

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -2,7 +2,7 @@
     "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
     "spaces": 2,
     "generator-cli": {
-        "version": "7.9.0-20240830.150238-24",
+        "version": "7.9.0-20240904.090300-33",
         "repository": {
             "downloadUrl": "https://oss.sonatype.org/content/repositories/snapshots/org/openapitools/openapi-generator-cli/7.9.0-SNAPSHOT/openapi-generator-cli-${versionName}.jar"
         },

--- a/src/v2/generated/apis/CompaniesApi.ts
+++ b/src/v2/generated/apis/CompaniesApi.ts
@@ -58,17 +58,26 @@ export class CompaniesApiRequestFactory extends BaseAPIRequestFactory {
 
         // Query Params
         if (ids !== undefined) {
-            requestContext.setQueryParam("ids", ObjectSerializer.serialize(ids, "Array<number>", "int64"));
+            const serializedParams = ObjectSerializer.serialize(ids, "Array<number>", "int64");
+            for (const serializedParam of serializedParams) {
+                requestContext.appendQueryParam("ids", serializedParam);
+            }
         }
 
         // Query Params
         if (fieldIds !== undefined) {
-            requestContext.setQueryParam("fieldIds", ObjectSerializer.serialize(fieldIds, "Array<string>", "string"));
+            const serializedParams = ObjectSerializer.serialize(fieldIds, "Array<string>", "string");
+            for (const serializedParam of serializedParams) {
+                requestContext.appendQueryParam("fieldIds", serializedParam);
+            }
         }
 
         // Query Params
         if (fieldTypes !== undefined) {
-            requestContext.setQueryParam("fieldTypes", ObjectSerializer.serialize(fieldTypes, "Array<'enriched' | 'global' | 'relationship-intelligence'>", "string"));
+            const serializedParams = ObjectSerializer.serialize(fieldTypes, "Array<'enriched' | 'global' | 'relationship-intelligence'>", "string");
+            for (const serializedParam of serializedParams) {
+                requestContext.appendQueryParam("fieldTypes", serializedParam);
+            }
         }
 
 
@@ -159,12 +168,18 @@ export class CompaniesApiRequestFactory extends BaseAPIRequestFactory {
 
         // Query Params
         if (fieldIds !== undefined) {
-            requestContext.setQueryParam("fieldIds", ObjectSerializer.serialize(fieldIds, "Array<string>", "string"));
+            const serializedParams = ObjectSerializer.serialize(fieldIds, "Array<string>", "string");
+            for (const serializedParam of serializedParams) {
+                requestContext.appendQueryParam("fieldIds", serializedParam);
+            }
         }
 
         // Query Params
         if (fieldTypes !== undefined) {
-            requestContext.setQueryParam("fieldTypes", ObjectSerializer.serialize(fieldTypes, "Array<'enriched' | 'global' | 'relationship-intelligence'>", "string"));
+            const serializedParams = ObjectSerializer.serialize(fieldTypes, "Array<'enriched' | 'global' | 'relationship-intelligence'>", "string");
+            for (const serializedParam of serializedParams) {
+                requestContext.appendQueryParam("fieldTypes", serializedParam);
+            }
         }
 
 

--- a/src/v2/generated/apis/ListsApi.ts
+++ b/src/v2/generated/apis/ListsApi.ts
@@ -199,12 +199,18 @@ export class ListsApiRequestFactory extends BaseAPIRequestFactory {
 
         // Query Params
         if (fieldIds !== undefined) {
-            requestContext.setQueryParam("fieldIds", ObjectSerializer.serialize(fieldIds, "Array<string>", "string"));
+            const serializedParams = ObjectSerializer.serialize(fieldIds, "Array<string>", "string");
+            for (const serializedParam of serializedParams) {
+                requestContext.appendQueryParam("fieldIds", serializedParam);
+            }
         }
 
         // Query Params
         if (fieldTypes !== undefined) {
-            requestContext.setQueryParam("fieldTypes", ObjectSerializer.serialize(fieldTypes, "Array<'enriched' | 'global' | 'list' | 'relationship-intelligence'>", "string"));
+            const serializedParams = ObjectSerializer.serialize(fieldTypes, "Array<'enriched' | 'global' | 'list' | 'relationship-intelligence'>", "string");
+            for (const serializedParam of serializedParams) {
+                requestContext.appendQueryParam("fieldTypes", serializedParam);
+            }
         }
 
 

--- a/src/v2/generated/apis/OpportunitiesApi.ts
+++ b/src/v2/generated/apis/OpportunitiesApi.ts
@@ -51,7 +51,10 @@ export class OpportunitiesApiRequestFactory extends BaseAPIRequestFactory {
 
         // Query Params
         if (ids !== undefined) {
-            requestContext.setQueryParam("ids", ObjectSerializer.serialize(ids, "Array<number>", "int64"));
+            const serializedParams = ObjectSerializer.serialize(ids, "Array<number>", "int64");
+            for (const serializedParam of serializedParams) {
+                requestContext.appendQueryParam("ids", serializedParam);
+            }
         }
 
 

--- a/src/v2/generated/apis/PersonsApi.ts
+++ b/src/v2/generated/apis/PersonsApi.ts
@@ -58,17 +58,26 @@ export class PersonsApiRequestFactory extends BaseAPIRequestFactory {
 
         // Query Params
         if (ids !== undefined) {
-            requestContext.setQueryParam("ids", ObjectSerializer.serialize(ids, "Array<number>", "int64"));
+            const serializedParams = ObjectSerializer.serialize(ids, "Array<number>", "int64");
+            for (const serializedParam of serializedParams) {
+                requestContext.appendQueryParam("ids", serializedParam);
+            }
         }
 
         // Query Params
         if (fieldIds !== undefined) {
-            requestContext.setQueryParam("fieldIds", ObjectSerializer.serialize(fieldIds, "Array<string>", "string"));
+            const serializedParams = ObjectSerializer.serialize(fieldIds, "Array<string>", "string");
+            for (const serializedParam of serializedParams) {
+                requestContext.appendQueryParam("fieldIds", serializedParam);
+            }
         }
 
         // Query Params
         if (fieldTypes !== undefined) {
-            requestContext.setQueryParam("fieldTypes", ObjectSerializer.serialize(fieldTypes, "Array<'enriched' | 'global' | 'relationship-intelligence'>", "string"));
+            const serializedParams = ObjectSerializer.serialize(fieldTypes, "Array<'enriched' | 'global' | 'relationship-intelligence'>", "string");
+            for (const serializedParam of serializedParams) {
+                requestContext.appendQueryParam("fieldTypes", serializedParam);
+            }
         }
 
 
@@ -159,12 +168,18 @@ export class PersonsApiRequestFactory extends BaseAPIRequestFactory {
 
         // Query Params
         if (fieldIds !== undefined) {
-            requestContext.setQueryParam("fieldIds", ObjectSerializer.serialize(fieldIds, "Array<string>", "string"));
+            const serializedParams = ObjectSerializer.serialize(fieldIds, "Array<string>", "string");
+            for (const serializedParam of serializedParams) {
+                requestContext.appendQueryParam("fieldIds", serializedParam);
+            }
         }
 
         // Query Params
         if (fieldTypes !== undefined) {
-            requestContext.setQueryParam("fieldTypes", ObjectSerializer.serialize(fieldTypes, "Array<'enriched' | 'global' | 'relationship-intelligence'>", "string"));
+            const serializedParams = ObjectSerializer.serialize(fieldTypes, "Array<'enriched' | 'global' | 'relationship-intelligence'>", "string");
+            for (const serializedParam of serializedParams) {
+                requestContext.appendQueryParam("fieldTypes", serializedParam);
+            }
         }
 
 

--- a/src/v2/generated/http/http.ts
+++ b/src/v2/generated/http/http.ts
@@ -104,6 +104,10 @@ export class RequestContext {
         this.url.searchParams.set(name, value);
     }
 
+    public appendQueryParam(name: string, value: string) {
+        this.url.searchParams.append(name, value);
+    }
+
     /**
      * Sets a cookie with the name and value. NO check  for duplicate cookies is performed
      *


### PR DESCRIPTION
Fixes an error that reads:

> `[...,last-event,next-event] are not valid Field IDs for this endpoint. Make sure that they all refer to non-list-specific company fields.","param":"fieldIds"}]}`

when trying to access the `/v2/companies` endpoint with a set of `fieldIds`.

Happens when trying to load companies from the `/v2/companies` endpoint with all available fields. For this, I am using the V2 API roughly as follows:

```ts
// get 100 company fields
const fields = (await companiesApi.getV2CompaniesFields({ limit: 100 })).data;
// get the IDs for all these fields
const fieldIds = fields.map(({id}) => id);
// get 100 companies with these fields
const companies = await companiesApi.getV2Companies({ limit: 100, fieldIds });
```

It generates a URL that roughly looks like:
```
https://api.affinity.co/v2/companies?limit=100&fieldIds=field-1142774%2Cfield-1142835%2Cfield-2122251%2Cfield-2123931%2Cfield-2130433%2Cfield-2148488%2Cfield-2287286
```
(comma-separated), but the API definition is 

https://github.com/planet-a-ventures/affinity-node/blob/ccaed2be6000194de9980f244eae7d2584b764cd/openapi/2024-08-28.json#L136

which means it should generate as `&fieldIds=fieldName1&fieldIds=fieldName2`, etc.

Fix based on https://github.com/OpenAPITools/openapi-generator/pull/19519