### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726963665,
-        "narHash": "sha256-POYLVr/nfCrHLr7lWW97obOQGpjgY3WaryoOBgpU3F4=",
+        "lastModified": 1727642351,
+        "narHash": "sha256-pZt0OFUqNpefmlkqKv0Ko/OlEtgNs1O/ManbsKu71u4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "09096b90f9d38ad730c3c347511e444647733891",
+        "rev": "c1897bcea75da90675dc3ed13b25c9cb9954e04e",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726745158,
-        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
+        "lastModified": 1727514110,
+        "narHash": "sha256-0YRcOxJG12VGDFH8iS8pJ0aYQQUAgo/r3ZAL+cSh9nk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
+        "rev": "85f7a7177c678de68224af3402ab8ee1bcee25c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/09096b90f9d38ad730c3c347511e444647733891' (2024-09-22)
  → 'github:NixOS/nixpkgs/c1897bcea75da90675dc3ed13b25c9cb9954e04e' (2024-09-29)
• Updated input 'pre-commit-hooks-nix':
    'github:cachix/pre-commit-hooks.nix/4e743a6920eab45e8ba0fbe49dc459f1423a4b74' (2024-09-19)
  → 'github:cachix/pre-commit-hooks.nix/85f7a7177c678de68224af3402ab8ee1bcee25c8' (2024-09-28)